### PR TITLE
Add Skeletal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Curated list of awesome groovy libraries, frameworks and resources. Inspired by 
 * [Gradle](https://www.gradle.org/) - A powerful build system for the JVM
 * [GMavenPlus](https://github.com/groovy/GMavenPlus) - A rewrite of GMaven, a Maven plugin for Groovy
 * [SDKMAN](https://sdkman.io) - The Software Development Kit Manager (Previously known as GVM)
+* [skeletal](https://github.com/cbmarcum/skeletal) - A simple project creation tool that uses packaged templates (successor of Lazybones)
 * [Lazybones](https://github.com/pledbrook/lazybones) - A simple project creation tool that uses packaged project templates.
 * [Jenkins job-dsl-plugin](https://github.com/jenkinsci/job-dsl-plugin) - A Groovy DSL for Jenkins Jobs
 * [travis-groovy](https://github.com/kdabir/travis-groovy) - execute groovy scripts on travis-ci


### PR DESCRIPTION
From Skeletal README:

> Skeletal is a fork of the popular Lazybones project created by Peter Ledbrook. Though unmaintained for some time, Lazybones continued to be used by other projects as a means to generate project layouts from templates and it was distributed on SDKMAN which made it more convenient to install and use. This came to an end with the shutdown of Bintray. in May 2021. Since this is where the application binaries and "built-in" templates lived, SDKMAN stopped distribution as the binaries were no longer available.